### PR TITLE
feat: 좋아요 한 이미지 DB서 추출 및 coffee form DB에 저장 기능 추가

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -39,6 +39,11 @@ exports.logIn = asyncCatcher(async (req, res, next) => {
 
   const token = await generateJWT(req.user.email);
 
+  // FIX ME: 진욱 작업 - 좋아요한 유저 이미지를 추출하기 위해 작성한 코드입니다. 현재 조회할 유저 id를 임의로 작성한 상태라 해당 코드 변경이 필요합니다.ㅈㅂ
+  const resultOnDemand = await User.find({
+    _id: { $in: ["62a13f789b2ff58829c6b587", "62a14f589b2ff58829c6b5ae"] },
+  }).select("image");
+
   return res.json({ success: true, token, user: req.user });
 });
 

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,10 +1,9 @@
+/* eslint-disable no-unused-vars */
 const CoffeeForm = require("../models/CoffeeForm");
 const asyncCatcher = require("../utils/asyncCatcher");
 const CoffeeFormService = require("../services/CoffeeFormService");
-// eslint-disable-next-line no-unused-vars
-
 const CoffeeFormInstance = new CoffeeFormService(CoffeeForm);
-// eslint-disable-next-line no-unused-vars
+
 exports.submit = asyncCatcher(async (req, res, next) => {
   const coffeeForm = {
     from: "62a1cb520f4d52f56ec0aca3",
@@ -14,11 +13,7 @@ exports.submit = asyncCatcher(async (req, res, next) => {
     accepted: false,
   };
 
-  try {
-    CoffeeFormInstance.RegisterCoffeeForm(coffeeForm);
-  } catch (err) {
-    console.log("err", err);
-  }
+  await CoffeeFormInstance.RegisterCoffeeForm(coffeeForm);
 
   res.json({ success: true });
 });

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,0 +1,24 @@
+const CoffeeForm = require("../models/CoffeeForm");
+const asyncCatcher = require("../utils/asyncCatcher");
+const CoffeeFormService = require("../services/CoffeeFormService");
+// eslint-disable-next-line no-unused-vars
+
+const CoffeeFormInstance = new CoffeeFormService(CoffeeForm);
+// eslint-disable-next-line no-unused-vars
+exports.submit = asyncCatcher(async (req, res, next) => {
+  const coffeeForm = {
+    from: "62a1cb520f4d52f56ec0aca3",
+    to: "62a13f789b2ff58829c6b587",
+    title: req.body.title,
+    content: req.body.content,
+    accepted: false,
+  };
+
+  try {
+    CoffeeFormInstance.RegisterCoffeeForm(coffeeForm);
+  } catch (err) {
+    console.log("err", err);
+  }
+
+  res.json({ success: true });
+});

--- a/loaders/middleware.js
+++ b/loaders/middleware.js
@@ -5,6 +5,7 @@ const passport = require("../config/passport");
 const checkJWT = require("../middlewares/checkJWT");
 const authRouter = require("../routes/auth");
 const userRouter = require("../routes/user");
+const indexRouter = require("../routes/index");
 const errorHandler = require("../middlewares/errorHandler");
 
 const initiateMiddlewares = (app) => {
@@ -21,6 +22,7 @@ const initiateMiddlewares = (app) => {
   app.use(passport.initialize());
   app.use(checkJWT);
 
+  app.use("/", indexRouter);
   app.use("/auth", authRouter);
   app.use("/user", userRouter);
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,7 @@
+const { submit } = require("../controllers/index");
+
+const router = require("express")();
+
+router.route("/coffee-form").post(submit);
+
+module.exports = router;

--- a/services/CoffeeFormService.js
+++ b/services/CoffeeFormService.js
@@ -1,0 +1,10 @@
+class CoffeeFormService {
+  constructor(coffeeFormModel) {
+    this.coffeeFormModel = coffeeFormModel;
+  }
+
+  RegisterCoffeeForm = async (query) =>
+    await this.coffeeFormModel.create(query);
+}
+
+module.exports = CoffeeFormService;


### PR DESCRIPTION
## 설명
[좋아요 한 이미지 DB서 추출](https://www.notion.so/vanillacoding/d507ae7e90094ed79f094ce86e488b5c?v=78859dbad7f04cf8a61d32359cb6b0b3&p=8417d911ec4b41a79a12f6c3b5978dd7) 기능과 coffee form DB에 저장 ([프론트](https://www.notion.so/vanillacoding/d507ae7e90094ed79f094ce86e488b5c?v=78859dbad7f04cf8a61d32359cb6b0b3&p=25dbe36d0d144940b1f99a4b78397d28)) [(백엔드](https://www.notion.so/vanillacoding/d507ae7e90094ed79f094ce86e488b5c?v=78859dbad7f04cf8a61d32359cb6b0b3&p=3493c7bc99c2495494ca8a2485b4c269)) 기능을 추가했습니다.

## 변경 또는 추가한 로직
- "좋아요 한 이미지 DB서 추출"은 도움 주셨던 mongoDB 쿼리문을 가지고 이미지를 가져오는 로직을 작성했습니다.
- server/controllers/auth.js에 `// FIX ME` 커멘트를 작성해두었습니다. (현재 저희 데이터가 없어) 이미지 추출을 하는 아이디가 하드 코딩된 상태입니다. 참고 부탁드립니다.
- "coffee form DB에 저장"은 프론트 단에서 페이지를 작성하고 제목과 내용을 제출 버튼 클릭 시에 /coffee-form 엔드포인트로 post 요청을 보냅니다. 