### PR TITLE
hotfix: dev dep 의 husky 가 설치되지 않는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "husky install",
-    "dev": "nodemon app"
+    "dev": "nodemon app",
+    "start": "NODE_ENV=production node app"
   },
   "repository": {
     "type": "git",
@@ -28,14 +29,14 @@
     "mongoose": "^6.3.5",
     "morgan": "^1.10.0",
     "passport": "^0.6.0",
-    "passport-jwt": "^4.0.0"
+    "passport-jwt": "^4.0.0",
+    "husky": "^8.0.1",
+    "lint-staged": "^13.0.0"
   },
   "devDependencies": {
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "husky": "^8.0.1",
-    "lint-staged": "^13.0.0",
     "nodemon": "^2.0.16",
     "prettier": "^2.6.2"
   },


### PR DESCRIPTION
## 설명

package.json 에 prepare 명령어에서 husky install 을 실행하는데,

husky 가 devdependency 에 들어있어서 프로덕션 중에 설치되지 않는 문제가 생겼습니다.

(프로덕션 환경에서는 devdep 이 설치되지 않습니다.)

이에, husky 와 lint-staged 를 dependencies 로 옮겼습니다.

## 변경 또는 추가한 로직
