### PR TITLE
hotfix: GET / 라우트 핸들러 작성

### DIFF
--- a/middlewares/protect.js
+++ b/middlewares/protect.js
@@ -1,5 +1,6 @@
 const jwt = require("jsonwebtoken");
 const { JWT_SECRET } = require("../config/secrets");
+const ErrorResponse = require("../utils/ErrorResponse");
 
 const protect = (req, res, next) => {
   if (
@@ -9,9 +10,11 @@ const protect = (req, res, next) => {
     const token = req.headers.authorization.split(" ")[1];
 
     jwt.verify(token, JWT_SECRET);
+
+    return next();
   }
 
-  next();
+  next(new ErrorResponse("unauthorized"));
 };
 
 module.exports = protect;

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,4 +7,6 @@ router.route("/coffee-form").post(protect, submitCoffeeRequest);
 
 router.route("/languages").get(protect, getLanguages);
 
+router.route("/").get((_, res) => res.json({ success: true }));
+
 module.exports = router;


### PR DESCRIPTION
## 설명

aws 는 배포가 완료된 서비스의 `/` 라우트에 GET 요청을 여러번 날리는 것으로 서비스의 상태를 확인하는데, 

저희 서버 리포지토리의 경우 `GET /` 에 대한 핸들러가 없어서 aws 가 저희의 프로젝트 상태를 '위험' 으로 변경했습니다. (ㅋㅋㅋ..)

## 변경 또는 추가한 로직

1. `/` 라우트에 GET 요청을 받는 핸들러를 추가했습니다.
2. 코드를 보다가 `protect` 미들웨어의 로직에 구멍이 있는 것을 확인하여 일부 수정했습니다.