### PR TITLE
feat: 채팅 목록 요청 핸들러 제작

### DIFF
--- a/controllers/chats.js
+++ b/controllers/chats.js
@@ -5,7 +5,10 @@ const User = require("../models/User");
 const ChatRoomService = require("../services/ChatRoomService");
 const UserService = require("../services/UserService");
 const asyncCatcher = require("../utils/asyncCatcher");
-const duplicateChatroomChecker = require("../utils/duplicateChatroomChecker");
+const {
+  duplicateChatroomChecker,
+  filterOutUserFromAttendants,
+} = require("../utils/helpers");
 
 const UserInstance = new UserService(User);
 const ChatRoomInstance = new ChatRoomService(ChatRoom);
@@ -43,10 +46,7 @@ exports.getAllChatRooms = asyncCatcher(async (req, res, next) => {
 
   const { chatroom } = await UserInstance.GetAllChatRoomListOfUser(userId);
 
-  const filteredChatrooms = chatroom.map(
-    ({ attendants }) =>
-      attendants.filter((user) => user._id.toString() !== userId.toString())[0]
-  );
+  const filteredChatrooms = filterOutUserFromAttendants(chatroom, userId);
 
   res.json({
     success: true,

--- a/controllers/chats.js
+++ b/controllers/chats.js
@@ -12,21 +12,19 @@ const ChatRoomInstance = new ChatRoomService(ChatRoom);
 
 exports.createChatroom = asyncCatcher(async (req, res, next) => {
   const { attendants } = req.body;
-  const attendant = mongoose.Types.ObjectId(attendants[1]);
+  const attendant = attendants[0];
+  const otherAttendant = mongoose.Types.ObjectId(attendants[1]);
 
-  const populatedChatRooms = await User.findById(attendants[0])
-    .populate({
-      path: "chatroom",
-      select: "attendants",
-    })
-    .select("chatroom");
+  const populatedChatRooms = await UserInstance.GetAllChatRoomsOfUser({
+    _id: attendant,
+  });
 
-  const isDuplicateChatRoom = duplicateChatroomChecker(
+  const chatRoomAlreadyExists = duplicateChatroomChecker(
     populatedChatRooms.chatroom,
-    attendant
+    otherAttendant
   );
 
-  if (isDuplicateChatRoom) {
+  if (chatRoomAlreadyExists) {
     return res.json({
       success: false,
       message: "같은 사람과 중복된 채팅방을 생성할 수 없습니다.",
@@ -38,4 +36,23 @@ exports.createChatroom = asyncCatcher(async (req, res, next) => {
   await UserInstance.AddChatRoomIdToAttendants(attendants, chatRoom._id);
 
   res.json({ success: true, roomId: chatRoom._id });
+});
+
+exports.getAllChatRooms = asyncCatcher(async (req, res, next) => {
+  const { _id: userId, name, image } = req.user;
+
+  const { chatroom } = await UserInstance.GetAllChatRoomListOfUser(userId);
+
+  const filteredChatrooms = chatroom.map(
+    ({ attendants }) =>
+      attendants.filter((user) => user._id.toString() !== userId.toString())[0]
+  );
+
+  res.json({
+    success: true,
+    chatrooms: filteredChatrooms,
+    name,
+    image,
+    id: userId,
+  });
 });

--- a/loaders/middleware.js
+++ b/loaders/middleware.js
@@ -25,7 +25,7 @@ const initiateMiddlewares = (app) => {
   );
   app.use(logger("dev"));
   app.use(express.json({ limit: "5mb" }));
-  app.use(express.urlencoded({ extended: false, limit: "5mb" }));
+  app.use(express.urlencoded({ extended: false, limit: "2mb" }));
 
   app.use(passport.initialize());
   app.use(checkJWT);

--- a/models/ChatRoom.js
+++ b/models/ChatRoom.js
@@ -15,12 +15,19 @@ const ChatRoomSchema = new mongoose.Schema({
   attendants: {
     type: [mongoose.Schema.Types.ObjectId],
     required: [true, "참가자는 두 명이어야 합니다."],
+    ref: "User",
   },
   chats: [ChatSchema],
-  count: {
-    type: Number,
-    default: 0,
-  },
+});
+
+ChatRoomSchema.virtual("lastChat").get(function () {
+  const lastIndex = this.chats.length - 1;
+
+  return this.chats[lastIndex];
+});
+
+ChatRoomSchema.virtual("count").get(function () {
+  return this.chats.length;
 });
 
 module.exports = mongoose.model("ChatRoom", ChatRoomSchema);

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1,7 +1,9 @@
-const { createChatroom } = require("../controllers/chats");
+const { createChatroom, getAllChatRooms } = require("../controllers/chats");
 
 const router = require("express")();
 
 router.route("/create").post(createChatroom);
+
+router.route("/list").get(getAllChatRooms);
 
 module.exports = router;

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -76,6 +76,26 @@ class UserService {
       { $addToSet: { chatroom: roomId } }
     );
   };
+
+  GetAllChatRoomsOfUser = async (userId) => {
+    return await this.userModel
+      .findById(userId)
+      .populate({
+        path: "chatroom",
+        select: "attendants",
+      })
+      .select("chatroom");
+  };
+
+  GetAllChatRoomListOfUser = async (userId) =>
+    await this.userModel
+      .findById(userId)
+      .populate({
+        path: "chatroom",
+        select: "attendants",
+        populate: { path: "attendants", select: "name image" },
+      })
+      .select("chatroom");
 }
 
 module.exports = UserService;

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,0 +1,24 @@
+exports.filterOutUserFromAttendants = (chatroom, userId) => {
+  return chatroom.map(({ attendants, _id }) => {
+    const friend = attendants.filter(
+      (user) => user._id.toString() !== userId.toString()
+    )[0];
+
+    return {
+      name: friend.name,
+      id: friend._id,
+      image: friend.image,
+      roomId: _id,
+    };
+  });
+};
+
+exports.duplicateChatroomChecker = (chatrooms, attendant) => {
+  for (const room of chatrooms) {
+    if (room.attendants.includes(attendant)) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## 설명

GET /chat/list 에서 유저가 가진 모든 채팅방의 목록을 반환합니다. 
더불어, 이 핸들러가 chat 탭의 로그인 기능도 수행해야 하다보니 사용자의 이름, 이미지, 아이디를 같이 반환합니다.

```
{
    "success": true,
    "chatrooms": [
        {
            "name": "시바견",
            "id": "62a408360613de8cdaab782f",
            "image": "https://sinder-image-bucket.s3.amazonaws.com/Sb%40xx.com.jpg",
            "roomId": "62a5d1bb9ad487973689a861"
        }
    ],
    "name": "황인택",
    "image": "https://sinder-image-bucket.s3.amazonaws.com/Vc22%40xx.com.jpg",
    "id": "62a405761a48da6263ead7d4"
}
```

## 변경 또는 추가한 로직

회원가입 시 첨부할 수 있는 사진의 크기를 최대 2mb 로 낮췄습니다.
