### PR TITLE
feat: 채팅방 소켓 제작

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,16 @@
 const express = require("express");
+const { createServer } = require("http");
 const initiateMongoDB = require("./config/mongodb");
 const initiateMiddlewares = require("./loaders/middleware");
 const { PORT } = require("./config/secrets");
+const initiateSocketIO = require("./loaders/socket");
 
 const app = express();
+const server = createServer(app);
 
 initiateMongoDB();
+
+initiateSocketIO(server);
 
 initiateMiddlewares(app);
 

--- a/loaders/socket.js
+++ b/loaders/socket.js
@@ -1,0 +1,41 @@
+const { Server } = require("socket.io");
+const ChatRoom = require("../models/ChatRoom");
+const ChatRoomService = require("../services/ChatRoomService");
+
+const ChatRoomInstance = new ChatRoomService(ChatRoom);
+
+const initiateSocketIO = (server) => {
+  const io = new Server(server, {
+    cors: {
+      origin: [
+        "http://localhost:3000",
+        "http://localhost:3001",
+        "http://localhost:3002",
+      ],
+      methods: ["GET", "POST"],
+    },
+  });
+
+  io.on("connection", (socket) => {
+    socket.on("joinRoom", async (roomId) => {
+      const { chats } = await ChatRoomInstance.GetChatHistory(roomId).catch(
+        () => {
+          socket.to(roomId).emit("error", "채팅 기록을 불러오지 못했습니다.");
+        }
+      );
+      socket.join(roomId);
+
+      socket.to(roomId).emit("joinedRoom", chats);
+
+      socket.on("chat", async (chat) => {
+        await ChatRoomInstance.SaveChats(roomId, chat).catch(() => {
+          socket.to(roomId).emit("error", "채팅을 저장하지 못했습니다.");
+        });
+
+        socket.broadcast.to(roomId).emit("chat-broadcast", chat);
+      });
+    });
+  });
+};
+
+module.exports = initiateSocketIO;

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
+    "husky": "^8.0.1",
     "joi": "^17.6.0",
     "jsonwebtoken": "^8.5.1",
+    "lint-staged": "^13.0.0",
     "mongoose": "^6.3.5",
     "morgan": "^1.10.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",
-    "husky": "^8.0.1",
-    "lint-staged": "^13.0.0"
+    "socket.io": "^4.5.1"
   },
   "devDependencies": {
     "eslint": "^8.17.0",

--- a/services/ChatRoomService.js
+++ b/services/ChatRoomService.js
@@ -10,6 +10,13 @@ class ChatRoomService {
 
   GetChatHistory = async (roomId) =>
     await this.chatRoomModel.findById(roomId).select("chats");
+
+  SaveChats = async (roomId, chat) => {
+    await this.chatRoomModel.updateOne(
+      { _id: roomId },
+      { $push: { chats: chat } }
+    );
+  };
 }
 
 module.exports = ChatRoomService;


### PR DESCRIPTION
## 설명

채팅방에서 소켓에 입장을 시도하면 받아주는 소켓 서버를 제작했습니다.

클라이언트는 자신의 DB 에 저장된 chatroom 의 아이디 값을 소켓의 룸 아이디로 사용하게 됩니다.
따라서 chatroom 에 저장된 두 명은 같은 chatroom 아이디로 같은 소켓에 입장하게 됩니다.

소켓 룸에 입장하면 서버 소켓 로직 내부에서 채팅 기록을 전부 보내줍니다.
그리고 소켓 룸에 채팅이 들어올 때 마다 디비에 채팅을 저장하도록 만들었습니다.

위의 방법이 굉장히 비효율적이라는 것을 알고있지만 우선 채팅 기능이 원활히 작동하는 것을 확인 하고 
수정하려 합니다.

## 변경 또는 추가한 로직
설치한 라이브러리:
1. socket.io - 소켓을 여는데 있어 가장 편리하고 공식문서도 잘 돼 있어서
