### PR TITLE
feat: 레디스를 응용한 채팅 저장 로직 완료

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,17 +1,17 @@
 const express = require("express");
-const { createServer } = require("http");
+const http = require("http");
 const initiateMongoDB = require("./config/mongodb");
 const initiateMiddlewares = require("./loaders/middleware");
 const { PORT } = require("./config/secrets");
 const initiateSocketIO = require("./loaders/socket");
 
 const app = express();
-const server = createServer(app);
-
-initiateMongoDB();
+const server = http.createServer(app);
 
 initiateSocketIO(server);
 
+initiateMongoDB();
+
 initiateMiddlewares(app);
 
-app.listen(PORT);
+server.listen(PORT);

--- a/config/redis.js
+++ b/config/redis.js
@@ -1,0 +1,6 @@
+const Redis = require("ioredis");
+const secrets = require("./secrets");
+
+const redis = new Redis(secrets.UPSTASH_REDIS_URI);
+
+module.exports = redis;

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -7,4 +7,5 @@ module.exports = {
   AWS_S3_BUCKET_NAME: process.env.AWS_S3_BUCKET_NAME,
   AWS_S3_ACCESS_KEY_ID: process.env.AWS_S3_ACCESS_KEY_ID,
   AWS_S3_SECRET_ACCESS_KEY: process.env.AWS_S3_SECRET_ACCESS_KEY,
+  UPSTASH_REDIS_URI: process.env.UPSTASH_REDIS_URI,
 };

--- a/controllers/chats.js
+++ b/controllers/chats.js
@@ -39,7 +39,7 @@ exports.createChatroom = asyncCatcher(async (req, res, next) => {
 
   await UserInstance.AddChatRoomIdToAttendants(attendants, chatRoom._id);
 
-  res.json({ success: true, roomId: chatRoom._id });
+  res.json({ success: true, roomId: chatRoom._id, attendants });
 });
 
 exports.getAllChatRooms = asyncCatcher(async (req, res, next) => {
@@ -68,5 +68,7 @@ exports.visitChatRoom = asyncCatcher(async (req, res, next) => {
     return next(new ErrorResponse("unauthorized"));
   }
 
-  res.json({ success: true });
+  const { attendants } = await ChatRoomInstance.GetAttendants(roomId);
+
+  res.json({ success: true, attendants });
 });

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -69,3 +69,11 @@ exports.getProfileInfo = asyncCatcher(async (req, res, next) => {
 
   res.json({ success: true, profile: populatedProfile });
 });
+
+exports.getUserChatInfo = asyncCatcher(async (req, res, next) => {
+  const { userId } = req.params;
+
+  const userChatInfo = await User.findById(userId).select("name image");
+
+  res.json({ success: true, user: userChatInfo });
+});

--- a/models/ChatRoom.js
+++ b/models/ChatRoom.js
@@ -7,9 +7,8 @@ const ChatSchema = new mongoose.Schema({
     ref: "User",
   },
   text: String,
+  createdAt: Number,
 });
-
-ChatSchema.set("timestamps", true);
 
 const ChatRoomSchema = new mongoose.Schema({
   attendants: {
@@ -18,16 +17,6 @@ const ChatRoomSchema = new mongoose.Schema({
     ref: "User",
   },
   chats: [ChatSchema],
-});
-
-ChatRoomSchema.virtual("lastChat").get(function () {
-  const lastIndex = this.chats.length - 1;
-
-  return this.chats[lastIndex];
-});
-
-ChatRoomSchema.virtual("count").get(function () {
-  return this.chats.length;
 });
 
 module.exports = mongoose.model("ChatRoom", ChatRoomSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "husky": "^8.0.1",
+        "ioredis": "^5.0.6",
         "joi": "^17.6.0",
         "jsonwebtoken": "^8.5.1",
         "lint-staged": "^13.0.0",
@@ -142,6 +143,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
+      "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -825,6 +831,14 @@
       "dev": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -1943,6 +1957,50 @@
         "node": ">=10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.0.6.tgz",
+      "integrity": "sha512-KUm7wPzIet9QrFMoMm09/4bkfVKBUD9KXwBitP3hrNkZ+A6NBndweXGwYIB/7szHcTZgfo7Kvx88SxljJV4D9A==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.0.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/ip": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
@@ -2342,10 +2400,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -3220,6 +3288,25 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -3638,6 +3725,11 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -4195,6 +4287,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ioredis/commands": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
+      "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -4697,6 +4794,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -5521,6 +5623,37 @@
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true
     },
+    "ioredis": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.0.6.tgz",
+      "integrity": "sha512-KUm7wPzIet9QrFMoMm09/4bkfVKBUD9KXwBitP3hrNkZ+A6NBndweXGwYIB/7szHcTZgfo7Kvx88SxljJV4D9A==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.0.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "ip": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
@@ -5825,10 +5958,20 @@
         }
       }
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -6469,6 +6612,19 @@
         "picomatch": "^2.2.1"
       }
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -6777,6 +6933,11 @@
       "requires": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "husky": "^8.0.1",
+    "ioredis": "^5.0.6",
     "joi": "^17.6.0",
     "jsonwebtoken": "^8.5.1",
     "lint-staged": "^13.0.0",

--- a/routes/user.js
+++ b/routes/user.js
@@ -3,6 +3,7 @@ const {
   getCoffeePrice,
   likeUser,
   getProfileInfo,
+  getUserChatInfo,
 } = require("../controllers/user");
 const protect = require("../middlewares/protect");
 
@@ -15,5 +16,7 @@ router.route("/profile").get(protect, getProfileInfo);
 router.route("/:userId/recommend").get(protect, recommendUser);
 
 router.route("/:userId/price").get(protect, getCoffeePrice);
+
+router.route("/:userId/chat-info").get(protect, getUserChatInfo);
 
 module.exports = router;


### PR DESCRIPTION
## 설명

클라이언트와 소켓 연결하는 로직을 작성했습니다.
웹뷰에서 소켓이 안된다는 문제를 뒤늦게 알아채서 멀쩡한 소켓 로직을 뒤엎는 바람에 시간이 조금 지체됐습니다..

이 브랜치는 채팅을 저장하는 로직이 인터넷에 나오지 않아 제 나름으로 레디스를 응용해 저장 로직을 만든 기록입니다.

로직에 대해 간략히 소개를 해드리겠습니다.
- 두 유저 간의 채팅은 두 유저만이 들어갈 수 있는 Room 에서 이루어집니다.
- 룸에서 오고가는 메시지는 서버를 거치며 하나하나 레디스에 저장됩니다. 
- `<ROOM_ID>: [<CHAT_1>,<CHAT_2>,...]`
- (위와 같은 키: 값 형태로 레디스에 push 됩니다.)
- 그렇게 모든 채팅을 레디스에 저장하고 있다가 유저 중 한 명이 나가면 레디스의 저장되어 있던 모든 메시지들을 몽고 디비에 저장한 다음 레디스의 ROOM_ID 키를 삭제합니다.

## 변경 또는 추가한 로직

설치한 라이브러리:
- ioredis - Upstash(클라우드 Redis) 를 사용했는데, 여기 공식문서에 ioredis 로의 연결법이 가장 깔끔했고, ioredis 자체가 다른 라이브러리에 비해 업데이트가 잦아 보여서 선택했습니다.

`ChatRoomService` 에서 redis 를 주입받을 수 있도록 로직을 추가했습니다.